### PR TITLE
Update VertexHeightMap16 to work in KSP 1.9.1.

### DIFF
--- a/src/KEX-VertexHeightMap16/converter/Program.cs
+++ b/src/KEX-VertexHeightMap16/converter/Program.cs
@@ -38,7 +38,7 @@ namespace KopernicusExpansion
                     for (Int32 y = 0; y < height; y++)
                     {
                         Int32 index = (y * width + x) * 2;
-                        newImage.SetPixel(x, y, Color.FromArgb(data[index + 1], 0, data[index], 0));
+                        newImage.SetPixel(x, y, Color.FromArgb(255, 0, data[index], data[index + 1]));
                     }
                 }
 

--- a/src/KEX-VertexHeightMap16/plugin/PQSMod_VertexHeightMap16.cs
+++ b/src/KEX-VertexHeightMap16/plugin/PQSMod_VertexHeightMap16.cs
@@ -1,5 +1,11 @@
-﻿using System;
+﻿using Kopernicus.Components;
+using Kopernicus.Configuration;
+using Kopernicus.Constants;
+using System;
+using System.Collections.Generic;
+using Kopernicus.Configuration.Parsing;
 using UnityEngine;
+using UnityEngine.Rendering;
 
 namespace KopernicusExpansion
 {
@@ -14,10 +20,15 @@ namespace KopernicusExpansion
             {
                 // Get the Color, not the Float-Value from the Map
                 Color32 c = heightMap.GetPixelColor32(data.u, data.v);
+
+                //Debug.Log("[KopEx VertexHeightMap16] " + data.u + ", " + data.v + ", " + c);
                 
                 // Get the height data from the terrain
-                Double height = BitConverter.ToUInt16(new [] {c.g, c.a}, 0) / (Double) UInt16.MaxValue;
-                
+                Double height = (Double) BitConverter.ToUInt16(new byte[] {c.b, c.g}, 0) / (Double) UInt16.MaxValue;
+
+                //Debug.Log("[KopEx VertexHeightMap16] " + height + ", " + c.g + ", " + c.a + ", " + BitConverter.ToUInt16(new byte[] { c.g, c.a }, 0));
+                //Debug.Log("[KopEx VertexHeightMap16] " + heightMapOffset + ", " + heightMapDeformity);
+
                 // Apply it
                 data.vertHeight += heightMapOffset + heightMapDeformity * height;
             }

--- a/src/KEX-VertexHeightMap16/plugin/VertexHeightMap16.cs
+++ b/src/KEX-VertexHeightMap16/plugin/VertexHeightMap16.cs
@@ -10,11 +10,12 @@ namespace KopernicusExpansion
 {
     namespace VertexHeightMap32
     {
+        [RequireConfigType(Kopernicus.ConfigParser.Enumerations.ConfigType.Node)]
         public class VertexHeightMap16 : ModLoader<PQSMod_VertexHeightMap16>
         {    
             // The map texture for the planet
             [ParserTarget("map")]
-            public MapSOParserRGB<MapSO> heightMap
+            public MapSOParserRGB<MapSO> HeightMap
             {
                 get { return Mod.heightMap; }
                 set { Mod.heightMap = value; }
@@ -22,7 +23,7 @@ namespace KopernicusExpansion
 
             // Height map offset
             [ParserTarget("offset")]
-            public NumericParser<Double> heightMapOffset 
+            public NumericParser<Double> HeightMapOffset 
             {
                 get { return Mod.heightMapOffset; }
                 set { Mod.heightMapOffset = value; }
@@ -30,7 +31,7 @@ namespace KopernicusExpansion
 
             // Height map offset
             [ParserTarget("deformity")]
-            public NumericParser<Double> heightMapDeformity
+            public NumericParser<Double> HeightMapDeformity
             {
                 get { return Mod.heightMapDeformity; }
                 set { Mod.heightMapDeformity = value; }
@@ -38,7 +39,7 @@ namespace KopernicusExpansion
 
             // Height map offset
             [ParserTarget("scaleDeformityByRadius")]
-            public NumericParser<Boolean> scaleDeformityByRadius
+            public NumericParser<Boolean> ScaleDeformityByRadius
             {
                 get { return Mod.scaleDeformityByRadius; }
                 set { Mod.scaleDeformityByRadius = value; }


### PR DESCRIPTION
While VertexHeight PQS Mods themselves appear to not require any changes to update to KSP 1.9.1 (for instance, the VertexHeightDeformity expansion can be re-compiled for KSP 1.9.1 without any changes required to its code), the way KSP loads maps was changed in 1.8. Previously, the VertexHeightMap16 mod would use the alpha color channel to store the lower 8-bit of the 16-bit height value, but KSP now discards the value in the alpha channel when loading heightmaps. Therefore, I changed the code to instead use the blue and green color channels to store the height information. I also updated the converter program to use this new format. This should make VertexHeightMap16 be usable in KSP 1.9.1 again.