### PR TITLE
Update VertexHeightMap16 to work in KSP 1.9 and above, and add the VertexHeightMap24 PQSMod.

### DIFF
--- a/src/KEX-VertexHeightMap16/converter/Program.cs
+++ b/src/KEX-VertexHeightMap16/converter/Program.cs
@@ -38,7 +38,7 @@ namespace KopernicusExpansion
                     for (Int32 y = 0; y < height; y++)
                     {
                         Int32 index = (y * width + x) * 2;
-                        newImage.SetPixel(x, y, Color.FromArgb(data[index + 1], 0, data[index], 0));
+                        newImage.SetPixel(x, y, Color.FromArgb(255, 0, data[index], data[index + 1]));
                     }
                 }
 

--- a/src/KEX-VertexHeightMap16/converter/Program.cs
+++ b/src/KEX-VertexHeightMap16/converter/Program.cs
@@ -15,8 +15,18 @@ namespace KopernicusExpansion
                 Console.WriteLine("    * The texture is a greyscale .raw file, with only one channel saved.");
                 Console.WriteLine("    * The texture is 2 x 1");
                 Console.WriteLine("    * The texture is exported with Macintosh byte order");
-                Console.WriteLine("Press any key to continue...");
-                Console.ReadKey();
+                Console.WriteLine("Please select the bit-size of the input texture:");
+                Console.WriteLine("(1) - 16-bit (for use with VertexHeightMap16)");
+                Console.WriteLine("(2) - 32-bit (will be converted down to 24-bit for use with VertexHeightMap24)");
+                Console.WriteLine("(Press either '1' or '2' on your keyboard)");
+                char inK = Console.ReadKey().KeyChar;
+                Console.WriteLine();
+                if(inK != '1' && inK != '2')
+                {
+                    Console.WriteLine("Not recognized: " + inK);
+                    return;
+                }
+                bool bits24 = inK == '2';
 
                 // Load the texture
                 if (args.Length == 0 || !File.Exists(args[0]))
@@ -30,7 +40,7 @@ namespace KopernicusExpansion
 
 
                 // Create a new texture
-                Int32 height = (Int32) Math.Sqrt(data.Length / 4d);
+                Int32 height = (Int32) Math.Sqrt(data.Length / (bits24 ? 8d : 4d));
                 Int32 width = 2 * height;
                 Bitmap newImage = new Bitmap(width, height, PixelFormat.Format32bppArgb);
                 for (Int32 x = 0; x < width; x++)
@@ -38,7 +48,15 @@ namespace KopernicusExpansion
                     for (Int32 y = 0; y < height; y++)
                     {
                         Int32 index = (y * width + x) * 2;
-                        newImage.SetPixel(x, y, Color.FromArgb(255, 0, data[index], data[index + 1]));
+                        if (bits24) index *= 2;
+                        if (bits24)
+                        {
+                            newImage.SetPixel(x, y, Color.FromArgb(255, data[index], data[index + 1], data[index + 2]));
+                        }
+                        else
+                        {
+                            newImage.SetPixel(x, y, Color.FromArgb(255, 0, data[index], data[index + 1]));
+                        }
                     }
                 }
 

--- a/src/KEX-VertexHeightMap16/plugin/PQSMod_VertexHeightMap16.cs
+++ b/src/KEX-VertexHeightMap16/plugin/PQSMod_VertexHeightMap16.cs
@@ -1,5 +1,11 @@
-﻿using System;
+﻿using Kopernicus.Components;
+using Kopernicus.Configuration;
+using Kopernicus.Constants;
+using System;
+using System.Collections.Generic;
+using Kopernicus.Configuration.Parsing;
 using UnityEngine;
+using UnityEngine.Rendering;
 
 namespace KopernicusExpansion
 {
@@ -14,10 +20,15 @@ namespace KopernicusExpansion
             {
                 // Get the Color, not the Float-Value from the Map
                 Color32 c = heightMap.GetPixelColor32(data.u, data.v);
+
+                //Debug.Log("[KopEx VertexHeightMap16] " + data.u + ", " + data.v + ", " + c);
                 
                 // Get the height data from the terrain
-                Double height = BitConverter.ToUInt16(new [] {c.g, c.a}, 0) / (Double) UInt16.MaxValue;
-                
+                Double height = (Double) BitConverter.ToUInt16(new byte[] {c.b, c.g}, 0) / (Double) UInt16.MaxValue;
+
+                //Debug.Log("[KopEx VertexHeightMap16] " + height + ", " + c.g + ", " + c.a + ", " + BitConverter.ToUInt16(new byte[] { c.g, c.a }, 0));
+                //Debug.Log("[KopEx VertexHeightMap16] " + heightMapOffset + ", " + heightMapDeformity);
+
                 // Apply it
                 data.vertHeight += heightMapOffset + heightMapDeformity * height;
             }

--- a/src/KEX-VertexHeightMap16/plugin/PQSMod_VertexHeightMap24.cs
+++ b/src/KEX-VertexHeightMap16/plugin/PQSMod_VertexHeightMap24.cs
@@ -14,12 +14,12 @@ namespace KopernicusExpansion
         /// <summary>
         /// A heightmap PQSMod that can parse encoded 16bpp textures
         /// </summary>
-        public class PQSMod_VertexHeightMap16 : PQSMod_VertexHeightMap
+        public class PQSMod_VertexHeightMap24 : PQSMod_VertexHeightMap
         {
             public override void OnVertexBuildHeight(PQS.VertexBuildData data)
             {
                 // Apply it
-                data.vertHeight += heightMapOffset + heightMapDeformity * VertexHeightMap16.SampleHeightmap16(data.u, data.v, heightMap, false);
+                data.vertHeight += heightMapOffset + heightMapDeformity * VertexHeightMap16.SampleHeightmap16(data.u, data.v, heightMap, true);
             }
         }
     }

--- a/src/KEX-VertexHeightMap16/plugin/VertexHeightMap16.cs
+++ b/src/KEX-VertexHeightMap16/plugin/VertexHeightMap16.cs
@@ -10,11 +10,12 @@ namespace KopernicusExpansion
 {
     namespace VertexHeightMap32
     {
+        [RequireConfigType(Kopernicus.ConfigParser.Enumerations.ConfigType.Node)]
         public class VertexHeightMap16 : ModLoader<PQSMod_VertexHeightMap16>
         {    
             // The map texture for the planet
             [ParserTarget("map")]
-            public MapSOParserRGB<MapSO> heightMap
+            public MapSOParserRGB<MapSO> HeightMap
             {
                 get { return Mod.heightMap; }
                 set { Mod.heightMap = value; }
@@ -22,7 +23,7 @@ namespace KopernicusExpansion
 
             // Height map offset
             [ParserTarget("offset")]
-            public NumericParser<Double> heightMapOffset 
+            public NumericParser<Double> HeightMapOffset 
             {
                 get { return Mod.heightMapOffset; }
                 set { Mod.heightMapOffset = value; }
@@ -30,7 +31,7 @@ namespace KopernicusExpansion
 
             // Height map offset
             [ParserTarget("deformity")]
-            public NumericParser<Double> heightMapDeformity
+            public NumericParser<Double> HeightMapDeformity
             {
                 get { return Mod.heightMapDeformity; }
                 set { Mod.heightMapDeformity = value; }
@@ -38,7 +39,7 @@ namespace KopernicusExpansion
 
             // Height map offset
             [ParserTarget("scaleDeformityByRadius")]
-            public NumericParser<Boolean> scaleDeformityByRadius
+            public NumericParser<Boolean> ScaleDeformityByRadius
             {
                 get { return Mod.scaleDeformityByRadius; }
                 set { Mod.scaleDeformityByRadius = value; }

--- a/src/KEX-VertexHeightMap16/plugin/VertexHeightMap16.cs
+++ b/src/KEX-VertexHeightMap16/plugin/VertexHeightMap16.cs
@@ -5,6 +5,8 @@ using Kopernicus.ConfigParser.BuiltinTypeParsers;
 using Kopernicus.Configuration;
 using Kopernicus.Configuration.ModLoader;
 using Kopernicus.Configuration.Parsing;
+using UnityEngine;
+using UnityEngine.Rendering;
 
 namespace KopernicusExpansion
 {
@@ -43,6 +45,75 @@ namespace KopernicusExpansion
             {
                 get { return Mod.scaleDeformityByRadius; }
                 set { Mod.scaleDeformityByRadius = value; }
+            }
+
+            private static float SingleSample(Int32 x, Int32 y, MapSO heightMap, bool bits24)
+            {
+                // Get the Color, not the Float-Value from the Map
+                Color32 c = heightMap.GetPixelColor32(x, y);
+
+                // Get the height data from the terrain
+                float height = 0;
+                if (bits24)
+                {
+                    height = (float)BitConverter.ToUInt32(new byte[] { c.b, c.g, c.r, 0 }, 0) / (float)0x00FFFFFF;
+                }
+                else
+                {
+                    height = (float)BitConverter.ToUInt16(new byte[] { c.b, c.g }, 0) / (float)UInt16.MaxValue;
+                }
+
+                return height;
+            }
+
+            public static double SampleHeightmap16(Double u, Double v, MapSO heightMap, bool bits24)
+            {
+                BilinearCoords coords = VertexHeightMap16.ConstructBilinearCoords(u, v, heightMap);
+                return Mathf.Lerp(
+                    Mathf.Lerp(
+                        SingleSample(coords.xFloor, coords.yFloor, heightMap, bits24),
+                        SingleSample(coords.xCeiling, coords.yFloor, heightMap, bits24),
+                        coords.u),
+                    Mathf.Lerp(
+                        SingleSample(coords.xFloor, coords.yCeiling, heightMap, bits24),
+                        SingleSample(coords.xCeiling, coords.yCeiling, heightMap, bits24),
+                        coords.u),
+                    coords.v);
+            }
+
+            // Function taken from https://github.com/Kopernicus/pqsmods-standalone/blob/master/KSP/MapSO.cs L340
+            public static BilinearCoords ConstructBilinearCoords(Double x, Double y, MapSO heightMap)
+            {
+                // Create the struct
+                BilinearCoords coords = new BilinearCoords();
+
+                // Floor
+                x = Math.Abs(x - Math.Floor(x));
+                y = Math.Abs(y - Math.Floor(y));
+
+                // X to U
+                coords.x = x * heightMap.Width;
+                coords.xFloor = (Int32)Math.Floor(coords.x);
+                coords.xCeiling = (Int32)Math.Ceiling(coords.x);
+                coords.u = (Single)(coords.x - coords.xFloor);
+                if (coords.xCeiling == heightMap.Width) coords.xCeiling = 0;
+
+                // Y to V
+                coords.y = y * heightMap.Height;
+                coords.yFloor = (Int32)Math.Floor(coords.y);
+                coords.yCeiling = (Int32)Math.Ceiling(coords.y);
+                coords.v = (Single)(coords.y - coords.yFloor);
+                if (coords.yCeiling >= heightMap.Height) coords.yCeiling = heightMap.Height - 1;
+
+                // We're done
+                return coords;
+            }
+
+            public struct BilinearCoords
+            {
+                public Double x, y;
+                public Int32 xCeiling, xFloor, yCeiling, yFloor;
+                public Single u, v;
             }
         }
     }

--- a/src/KEX-VertexHeightMap16/plugin/VertexHeightMap24.cs
+++ b/src/KEX-VertexHeightMap16/plugin/VertexHeightMap24.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using Kopernicus;
+using Kopernicus.ConfigParser.Attributes;
+using Kopernicus.ConfigParser.BuiltinTypeParsers;
+using Kopernicus.Configuration;
+using Kopernicus.Configuration.ModLoader;
+using Kopernicus.Configuration.Parsing;
+
+namespace KopernicusExpansion
+{
+    namespace VertexHeightMap32
+    {
+        [RequireConfigType(Kopernicus.ConfigParser.Enumerations.ConfigType.Node)]
+        public class VertexHeightMap24 : ModLoader<PQSMod_VertexHeightMap24>
+        {
+            // The map texture for the planet
+            [ParserTarget("map")]
+            public MapSOParserRGB<MapSO> HeightMap
+            {
+                get { return Mod.heightMap; }
+                set { Mod.heightMap = value; }
+            }
+
+            // Height map offset
+            [ParserTarget("offset")]
+            public NumericParser<Double> HeightMapOffset
+            {
+                get { return Mod.heightMapOffset; }
+                set { Mod.heightMapOffset = value; }
+            }
+
+            // Height map offset
+            [ParserTarget("deformity")]
+            public NumericParser<Double> HeightMapDeformity
+            {
+                get { return Mod.heightMapDeformity; }
+                set { Mod.heightMapDeformity = value; }
+            }
+
+            // Height map offset
+            [ParserTarget("scaleDeformityByRadius")]
+            public NumericParser<Boolean> ScaleDeformityByRadius
+            {
+                get { return Mod.scaleDeformityByRadius; }
+                set { Mod.scaleDeformityByRadius = value; }
+            }
+        }
+    }
+}


### PR DESCRIPTION
These changes fix two major bugs in VertexHeightMap16 in order to make it functional in KSP 1.9 and above.
The way KSP loads maps was changed in 1.8. Previously, the VertexHeightMap16 mod would use the alpha color channel to store the lower 8-bit of the 16-bit height value, but KSP now discards the value in the alpha channel when loading heightmaps. Therefore, I changed the code to instead use the blue and green color channels to store the height information. I also updated the converter program to use this new format.
Additionally, there was a problem with KSP handling the 16-bit heightmap like a texture, meaning that it would apply bilinear interpolation whenever the map was sampled using UV coordinates. However, as the 16-bit heightmap uses two colors channels to carry a 16-bit integer, and not an actual color, the bilinear interpolation algorithm instead corrupts the 16-bit height data. I fixed this issue by only directly accessing data from the heightmap using pixel coordinates, which does not apply bilinear interpolation and simply returns the exact color of pixel the coordinates point to, and applying the bilinear interpolation on the correctly-calculated height data instead of the image colors.
Lastly, I added a VertexHeightmap24 PQSMod, which, instead of using two color channels of an image to carry 16-bit height data, uses all three color channels to carry 24-bit height data. I also modified the converter program to make it possible for the user to choose which of the now two formats they want to use.