### PR TITLE
Fix texture wrapping issue in VertexHeightMap16/24

### DIFF
--- a/src/KEX-VertexHeightMap16/plugin/VertexHeightMap16.cs
+++ b/src/KEX-VertexHeightMap16/plugin/VertexHeightMap16.cs
@@ -90,8 +90,8 @@ namespace KopernicusExpansion
                 // Floor
                 x = x - Math.Floor(x);
                 y = y - Math.Floor(y);
-				if(x < 0) x = 1.0 + x;
-				if(y < 0) y = 1.0 + y;
+		if(x < 0) x = 1.0 + x;
+		if(y < 0) y = 1.0 + y;
 
                 // X to U
                 coords.x = x * heightMap.Width;

--- a/src/KEX-VertexHeightMap16/plugin/VertexHeightMap16.cs
+++ b/src/KEX-VertexHeightMap16/plugin/VertexHeightMap16.cs
@@ -88,8 +88,10 @@ namespace KopernicusExpansion
                 BilinearCoords coords = new BilinearCoords();
 
                 // Floor
-                x = Math.Abs(x - Math.Floor(x));
-                y = Math.Abs(y - Math.Floor(y));
+                x = x - Math.Floor(x);
+                y = y - Math.Floor(y);
+				if(x < 0) x = 1.0 + x;
+				if(y < 0) y = 1.0 + y;
 
                 // X to U
                 coords.x = x * heightMap.Width;


### PR DESCRIPTION
Negative uv coordinates weren't being handled correctly before, causing a seam in generated heightmaps. This should fix that.