### PR TITLE
Fix VHM24 pixel data to vertex height conversion.

### DIFF
--- a/src/KEX-VertexHeightMap16/plugin/PQSMod_VertexHeightMap24.cs
+++ b/src/KEX-VertexHeightMap16/plugin/PQSMod_VertexHeightMap24.cs
@@ -12,7 +12,7 @@ namespace KopernicusExpansion
     namespace VertexHeightMap32
     {
         /// <summary>
-        /// A heightmap PQSMod that can parse encoded 16bpp textures
+        /// A heightmap PQSMod that can parse encoded 24bpp textures
         /// </summary>
         public class PQSMod_VertexHeightMap24 : PQSMod_VertexHeightMap
         {

--- a/src/KEX-VertexHeightMap16/plugin/VertexHeightMap16.cs
+++ b/src/KEX-VertexHeightMap16/plugin/VertexHeightMap16.cs
@@ -55,7 +55,7 @@ namespace KopernicusExpansion
                 float height = 0;
                 if (bits24)
                 {
-                    height = (float)((int)c.b | ((int)c.g << 8) | ((int)c.r << 8)) / (float)0x00FFFFFF;
+                    height = (float)((int)c.b | ((int)c.g << 8) | ((int)c.r << 16)) / (float)0x00FFFFFF;
                 }
                 else
                 {

--- a/src/KEX-VertexHeightMap16/plugin/VertexHeightMap24.cs
+++ b/src/KEX-VertexHeightMap16/plugin/VertexHeightMap24.cs
@@ -29,7 +29,7 @@ namespace KopernicusExpansion
                 set { Mod.heightMapOffset = value; }
             }
 
-            // Height map offset
+            // Height map deformity
             [ParserTarget("deformity")]
             public NumericParser<Double> HeightMapDeformity
             {
@@ -37,7 +37,6 @@ namespace KopernicusExpansion
                 set { Mod.heightMapDeformity = value; }
             }
 
-            // Height map offset
             [ParserTarget("scaleDeformityByRadius")]
             public NumericParser<Boolean> ScaleDeformityByRadius
             {


### PR DESCRIPTION
The red pixel color value not being right-shifted by the right amount in VHM24 caused VHM24 to break entirely. It should be fixed now, and I also edited some of the code comments that were inaccurate.